### PR TITLE
return this to fix dot chaining

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@
         original.call(ctx, param);
         if (done) done();
       });
+      return this;
     };
   }
 


### PR DESCRIPTION
when you don't return this, it breaks dot chaining, but if you return this inside fastdom, it causes a timing issue. returning this in case someone want to dot chain the jquery function.